### PR TITLE
Make fsi-mcp-server a dotnet tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 bin/
 obj/
+nupkg/
 /packages/
 riderModule.iml
 /_ReSharper.Caches/

--- a/README.md
+++ b/README.md
@@ -44,10 +44,13 @@ cd fsi-mcp-server
 dotnet pack server/fsi-mcp-server.fsproj -c Release
 dotnet tool install -g --add-source ./nupkg FsiMcp
 
-# Run (binds http://0.0.0.0:5020)
+# Run as HTTP server (binds http://0.0.0.0:5020)
 fsi-mcp
 
-# Pass-through fsi.exe args
+# Run as stdio MCP server (for clients that auto-spawn the process; no HTTP listener)
+fsi-mcp --stdio
+
+# Pass-through fsi.exe args (works in both modes)
 fsi-mcp --nologo --define:DEBUG --load:setup.fsx
 
 # Update / uninstall
@@ -179,16 +182,38 @@ Replace Rider's built-in F# Interactive with FSI Server for seamless AI integrat
 
 #### Setting Up Claude Code Integration
 
-Install the mcp server:
+If installed as the global tool (recommended), register stdio so Claude Code auto-spawns it per session — no need to start the server first:
 
-native:
 ```shell
- claude mcp add --transport sse fsi-server  http://localhost:5020/sse
+claude mcp add -s user fsi-mcp -- fsi-mcp --stdio --nologo
+```
+
+Stdio mode disables the hybrid console-REPL bridge (stdin is owned by JSON-RPC) and silences stdout-bound FSI echoing; everything still flows through the MCP tools and the event log.
+
+Alternatively, if you're already running fsi-mcp as a long-lived HTTP server, register the SSE endpoint:
+
+```shell
+claude mcp add --transport sse -s user fsi-mcp http://localhost:5020/sse
 ```
 
 This creates a seamless experience where you can work with F# interactively while Claude assists by executing code, running tests, and maintaining collaborative scripts.
 
 #### Setting Up Claude Desktop Integration
+
+Stdio (recommended — Claude Desktop launches the server itself):
+
+```json
+{
+  "mcpServers": {
+    "fsi-mcp": {
+      "command": "fsi-mcp",
+      "args": ["--stdio", "--nologo"]
+    }
+  }
+}
+```
+
+HTTP/SSE bridge (for an already-running fsi-mcp HTTP server):
 
 ```json
 {
@@ -201,6 +226,7 @@ This creates a seamless experience where you can work with F# interactively whil
       ]
     }
   }
+}
 ```
 
 #### Setting Up Github Copilot Integration

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A drop-in replacement for `fsi.exe` that adds MCP capabilities to F# Interactive
 
 ## Table of Contents
 
+- [Install as a .NET Global Tool](#install-as-a-net-global-tool)
 - [Why FSI MCP Server?](#why-fsi-mcp-server)
 - [Overview](#overview)
 - [Quick Start](#quick-start)
@@ -28,6 +29,34 @@ A drop-in replacement for `fsi.exe` that adds MCP capabilities to F# Interactive
   - [CLI Pass-through](#cli-pass-through)
 - [Requirements](#requirements)
 - [License](#license)
+
+## Install as a .NET Global Tool
+
+`fsi-mcp-server` packs as a .NET global tool (`PackageId: FsiMcp`, command: `fsi-mcp`).
+
+```bash
+# Option A - install from nuget.org (once published)
+dotnet tool install -g FsiMcp
+
+# Option B - install from a local clone of this repo
+git clone https://github.com/halcwb/fsi-mcp-server
+cd fsi-mcp-server
+dotnet pack server/fsi-mcp-server.fsproj -c Release
+dotnet tool install -g --add-source ./nupkg FsiMcp
+
+# Run (binds http://0.0.0.0:5020)
+fsi-mcp
+
+# Pass-through fsi.exe args
+fsi-mcp --nologo --define:DEBUG --load:setup.fsx
+
+# Update / uninstall
+dotnet tool update    -g FsiMcp                       # nuget.org
+dotnet tool update    -g --add-source ./nupkg FsiMcp  # local clone
+dotnet tool uninstall -g FsiMcp
+```
+
+The wrapper scripts in the repo root (`fsi-mcp`, `start-server.sh`) are dev-only and not needed once installed globally.
 
 ## Why FSI MCP Server?
 

--- a/fsi-mcp
+++ b/fsi-mcp
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+exec dotnet /Users/halcwb/Development/halcwb/forks/fsi-mcp-server/server/bin/Debug/net9.0/fsi-mcp-server.dll "$@"

--- a/server/FsiService.fs
+++ b/server/FsiService.fs
@@ -19,9 +19,10 @@ type FsiEvent = {
     SessionId: string
 }
 
-type FsiService(logger: ILogger<FsiService>, sessionId: string) =
+type FsiService(logger: ILogger<FsiService>, sessionId: string, ?isStdio: bool) =
     let mutable fsiProcess: Process option = None
     let eventQueue = ConcurrentQueue<FsiEvent>()
+    let isStdio = defaultArg isStdio false
 
     let getSourceName = function
         | Console -> "console"
@@ -69,7 +70,7 @@ type FsiService(logger: ILogger<FsiService>, sessionId: string) =
                 while not proc.HasExited do
                     let! line = proc.StandardOutput.ReadLineAsync() |> Async.AwaitTask
                     if not (isNull line) then
-                        Console.WriteLine(line)  // Pipe FSI output to console as normal                        
+                        if not isStdio then Console.WriteLine(line)  // Pipe FSI output to console (suppressed in stdio MCP mode to keep stdout clean for JSON-RPC)
                         createFsiEvent "output" "fsi" line |> addEvent //Fill event queue so MCP clients can follow along
             with
             | ex -> logger.LogError($"Output monitoring error: %s{ex.Message}")
@@ -82,8 +83,9 @@ type FsiService(logger: ILogger<FsiService>, sessionId: string) =
                     let! line = proc.StandardError.ReadLineAsync() |> Async.AwaitTask
                     if not (isNull line) then
                         logger.LogDebug("FSI-STDERR: {Line}", line)
-                        Console.WriteLine $"ERROR: %s{line}"
-                        Console.Out.Flush()  // Flush immediately for redirected stdout (Rider)
+                        if not isStdio then
+                            Console.WriteLine $"ERROR: %s{line}"
+                            Console.Out.Flush()  // Flush immediately for redirected stdout (Rider)
 
                         // Add error event to queue
                         let event = createFsiEvent "error" "fsi" line
@@ -103,7 +105,7 @@ type FsiService(logger: ILogger<FsiService>, sessionId: string) =
         logger.LogDebug("FSI-INPUT: SendToFsi from {Source}: {Code}", sourceName, code.Trim())
         match fsiProcess with
         | Some proc when not proc.HasExited ->
-            if source <> Console then //Don't pipe CLI input back to CLI.
+            if source <> Console && not isStdio then //Don't pipe CLI input back to CLI; suppressed in stdio MCP mode.
                 Console.WriteLine $"(%s{sourceName})> %s{code.Trim()}"
                 Console.Out.Flush()  // Flush immediately for redirected stdout (Rider)
 

--- a/server/Program.fs
+++ b/server/Program.fs
@@ -7,6 +7,7 @@ open System.Threading.Tasks
 open Microsoft.AspNetCore.Builder
 open Microsoft.AspNetCore.Hosting
 open Microsoft.Extensions.DependencyInjection
+open Microsoft.Extensions.Hosting
 open Microsoft.Extensions.Logging
 open Serilog
 
@@ -135,25 +136,66 @@ let createApp (args: string[]) (sessionId: string) =
     
     app, Task.WhenAll [| prodTask; consTask |]
 
+let runStdio (args: string[]) (sessionId: string) =
+    // Stdio MCP transport owns Console.In/Out for JSON-RPC.
+    // Use Generic Host (no ASP.NET, no console banner) and route logging only to the Serilog file sink.
+    let builder = Host.CreateApplicationBuilder()
+
+    builder.Logging.ClearProviders() |> ignore
+    builder.Logging.AddSerilog(Log.Logger) |> ignore
+
+    builder.Services.AddSingleton<FsiService.FsiService>(fun serviceProvider ->
+        let logger = serviceProvider.GetRequiredService<ILogger<FsiService.FsiService>>()
+        new FsiService.FsiService(logger, sessionId, true)
+    ) |> ignore
+
+    builder.Services.AddSingleton<FsiMcpTools.FsiTools>(fun serviceProvider ->
+        let fsiService = serviceProvider.GetRequiredService<FsiService.FsiService>()
+        let logger = serviceProvider.GetRequiredService<ILogger<FsiMcpTools.FsiTools>>()
+        new FsiMcpTools.FsiTools(fsiService, logger)
+    ) |> ignore
+
+    builder.Services
+        .AddMcpServer()
+        .WithStdioServerTransport()
+        .WithTools<FsiMcpTools.FsiTools>()
+    |> ignore
+
+    let host = builder.Build()
+    let fsiService = host.Services.GetRequiredService<FsiService.FsiService>()
+    fsiService.StartFsi(args) |> ignore
+
+    let lifetime = host.Services.GetRequiredService<IHostApplicationLifetime>()
+    lifetime.ApplicationStopping.Register(fun () -> fsiService.Cleanup()) |> ignore
+
+    host.Run()
+
 [<EntryPoint>]
 let main args =
+    // Recognise --stdio anywhere in argv; strip it before passing through to FSI.
+    let stdioMode = args |> Array.contains "--stdio"
+    let args = args |> Array.filter (fun a -> a <> "--stdio")
+
     // Generate session ID early for Serilog configuration
     let sessionId = Guid.NewGuid().ToString("N")[..7]
-    // OS specific temp path    
+    // OS specific temp path
     let tempPath = IO.Path.GetTempPath()
     let logFilePath = IO.Path.Combine(tempPath, $"fsi-mcp-debugging-{sessionId}.log")
-    // Configure Serilog early - before any other logging
+    // Configure Serilog early - file sink only; safe to use in stdio mode (no stdout writes).
     Log.Logger <- LoggerConfiguration()
         .MinimumLevel.Debug()
         .WriteTo.File(logFilePath)
         .CreateLogger()
-    
-    Log.Information("FSI MCP Server starting with session ID: {SessionId}", sessionId)
-    
+
+    Log.Information("FSI MCP Server starting (stdio={Stdio}) session={SessionId}", stdioMode, sessionId)
+
     try
-        let (app, consoleTask) = createApp args sessionId
-        let appTask = app.RunAsync()
-        Task.WaitAll([| appTask; consoleTask |])
+        if stdioMode then
+            runStdio args sessionId
+        else
+            let (app, consoleTask) = createApp args sessionId
+            let appTask = app.RunAsync()
+            Task.WaitAll([| appTask; consoleTask |])
         0
     finally
         Log.CloseAndFlush()

--- a/server/fsi-mcp-server.fsproj
+++ b/server/fsi-mcp-server.fsproj
@@ -6,7 +6,7 @@
         <RootNamespace>fsi_server</RootNamespace>
         <IsPackable>true</IsPackable>
         <PackageId>FsiMcp</PackageId>
-        <Version>0.1.0</Version>
+        <Version>0.2.0</Version>
         <PackAsTool>true</PackAsTool>
         <ToolCommandName>fsi-mcp</ToolCommandName>
         <PackageOutputPath>../nupkg</PackageOutputPath>

--- a/server/fsi-mcp-server.fsproj
+++ b/server/fsi-mcp-server.fsproj
@@ -4,6 +4,19 @@
         <OutputType>Exe</OutputType>
         <TargetFramework>net9.0</TargetFramework>
         <RootNamespace>fsi_server</RootNamespace>
+        <IsPackable>true</IsPackable>
+        <PackageId>FsiMcp</PackageId>
+        <Version>0.1.0</Version>
+        <PackAsTool>true</PackAsTool>
+        <ToolCommandName>fsi-mcp</ToolCommandName>
+        <PackageOutputPath>../nupkg</PackageOutputPath>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+        <Authors>halcwb</Authors>
+        <Description>FSI MCP Server - drop-in F# Interactive replacement exposing MCP tools over HTTP.</Description>
+        <PackageTags>fsharp;fsi;mcp;model-context-protocol</PackageTags>
+        <RepositoryUrl>https://github.com/halcwb/fsi-mcp-server</RepositoryUrl>
+        <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+        <RollForward>Major</RollForward>
     </PropertyGroup>
 
     <ItemGroup>
@@ -11,6 +24,10 @@
         <Compile Include="McpToolNames.fs" />
         <Compile Include="FsiMcpTools.fs" />
         <Compile Include="Program.fs" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <None Include="../README.md" Pack="true" PackagePath="\" />
     </ItemGroup>
 
     <ItemGroup>

--- a/server/runtimeconfig.template.json
+++ b/server/runtimeconfig.template.json
@@ -1,0 +1,6 @@
+{
+  "frameworks": [
+    { "name": "Microsoft.NETCore.App", "version": "9.0.0" },
+    { "name": "Microsoft.AspNetCore.App", "version": "9.0.0" }
+  ]
+}

--- a/start-server.sh
+++ b/start-server.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Start the FSI MCP Server
+dotnet server/bin/Debug/net9.0/fsi-mcp-server.dll


### PR DESCRIPTION
# feat: pack as .NET global tool (FsiMcp / fsi-mcp)

## Summary

Make the server installable via `dotnet tool install -g FsiMcp` so users can invoke `fsi-mcp` from anywhere, instead of cloning the repo and running `dotnet run` or shell wrappers.

This is a packaging-only change. The FSI wrapper, MCP tools, transport, port, and runtime behavior are untouched — `fsi-mcp` and `dotnet run --project server` produce identical processes.

## Motivation

Today, using the server requires cloning the repo, building, and either running `dotnet run` from the project root or pointing IDEs at an absolute path inside `bin/`. Distribution as a .NET global tool removes those steps and makes the README's IDE/Claude/Copilot integration snippets reproducible by anyone with the .NET SDK installed.

The pattern is borrowed from [Neftedollar/FsLangMCP](https://github.com/Neftedollar/FsLangMCP), which ships an F# MCP server the same way (`dotnet tool install -g FsLangMcp` → `fslangmcp`).

## Changes

### `server/fsi-mcp-server.fsproj`

Added tool packaging metadata to the existing `<PropertyGroup>`:

```xml
<IsPackable>true</IsPackable>          <!-- Microsoft.NET.Sdk.Web defaults to false -->
<PackageId>FsiMcp</PackageId>
<Version>0.1.0</Version>
<PackAsTool>true</PackAsTool>
<ToolCommandName>fsi-mcp</ToolCommandName>
<PackageOutputPath>../nupkg</PackageOutputPath>
<PackageReadmeFile>README.md</PackageReadmeFile>
<Authors>...</Authors>
<Description>FSI MCP Server - drop-in F# Interactive replacement exposing MCP tools over HTTP.</Description>
<PackageTags>fsharp;fsi;mcp;model-context-protocol</PackageTags>
<RepositoryUrl>https://github.com/jovaneyck/fsi-mcp-server</RepositoryUrl>
<PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
<RollForward>Major</RollForward>
```

Plus a `<None Include="../README.md" Pack="true" PackagePath="\" />` so the README ships inside the package.

### `server/runtimeconfig.template.json` (new)

Required when packing a `Microsoft.NET.Sdk.Web` project as a tool — without it, `dotnet tool install` does not record the `Microsoft.AspNetCore.App` framework reference and the installed binary fails to start with *"It was not possible to find any compatible framework version"*.

```json
{
  "frameworks": [
    { "name": "Microsoft.NETCore.App",     "version": "9.0.0" },
    { "name": "Microsoft.AspNetCore.App",  "version": "9.0.0" }
  ]
}
```

### `.gitignore`

Added `nupkg/` so the pack output stays untracked.

### `README.md`

New "Install as a .NET Global Tool" section near the top with both NuGet (once published) and local-clone install paths, plus update/uninstall commands and a note that the repo-root `fsi-mcp` / `start-server.sh` wrappers become dev-only.

## What is *not* changed

- `server/Program.fs`, `server/FsiService.fs`, `server/FsiMcpTools.fs`, `server/McpToolNames.fs` — no edits.
- HTTP transport on hardcoded `http://0.0.0.0:5020` — same limitation flagged in `CLAUDE.md`, out of scope here.
- The repo-root `fsi-mcp` / `start-server.sh` wrappers — kept for in-repo dev workflow.
- Stdio transport — not added; this PR keeps the existing HTTP/SSE design.

## Verification

```bash
# Pack
dotnet pack server/fsi-mcp-server.fsproj -c Release
# → nupkg/FsiMcp.0.1.0.nupkg

# Install from local feed
dotnet tool install -g --add-source ./nupkg FsiMcp

# Run
fsi-mcp --nologo &
curl http://localhost:5020/health   # → "Ready to work!"
```

End-to-end MCP smoke test (Streamable HTTP on `POST /`):

| Step | Result |
|---|---|
| `initialize` | server `fsi-mcp-server 0.1.0.0`, session id returned via `Mcp-Session-Id` header |
| `tools/list` | `send_fsharp_code`, `load_f_sharp_script`, `get_recent_fsi_events`, `get_fsi_status` |
| `tools/call send_fsharp_code` with `printfn "hello world";;` | `Code sent to FSI and logged` |
| `tools/call get_recent_fsi_events` | event log contains `INPUT (api:claude): printfn "hello world";;` followed by `OUTPUT (fsi): > hello world` and `val it: unit = ()` |
| `pkill -f fsi-mcp`, retry init | connection refused — confirms the installed binary owns the process |

## Notes for maintainers

- Bumping `<Version>` is the only release step before `dotnet nuget push`; the package id `FsiMcp` is currently unclaimed on nuget.org but please verify before publishing.
- The `RepositoryUrl` and `Authors` placeholders should be set to whatever you prefer for the upstream package.
- `<RollForward>Major</RollForward>` is included so the tool keeps working when only newer .NET runtimes are installed; remove it if you want to pin strictly to net9.0.

cat /tmp/fsi-mcp-pr-stdio.md
# feat: add stdio MCP transport (`--stdio`) for client auto-spawn

## Summary

Add a `--stdio` flag that switches `fsi-mcp` from its HTTP/SSE listener to a stdio MCP transport. This lets MCP clients (Claude Code, Claude Desktop, Cursor, ...) launch `fsi-mcp` as a subprocess on demand and talk JSON-RPC over its stdin/stdout — the standard pattern for stdio-only MCP clients — without the user having to start a long-lived HTTP server first.

HTTP/SSE mode remains the default and is unchanged. `--stdio` is purely additive.

## Motivation

After packaging as a .NET global tool (#prev-PR), the next obstacle for casual users was that `fsi-mcp` only spoke HTTP. To use it from Claude Desktop, Claude Code, or any other MCP client that prefers spawning servers itself, the user had to:

1. Open a terminal, run `fsi-mcp` to start the HTTP server.
2. Configure the client with an SSE URL.
3. Remember to restart the server every time it died.

With `--stdio`, the client config becomes a single `command: "fsi-mcp", args: ["--stdio", "--nologo"]` line, and the server lifecycle is owned by the client. This mirrors the integration story of comparable tools like `fslangmcp` and `mcp-server-everything`.

## Design notes

- **Mode switch, not replacement.** Stdio mode disables the hybrid console-REPL bridge — when the MCP transport owns `stdin`/`stdout` for JSON-RPC, there is no terminal stdin to read from and any write to `Console.Out` corrupts the protocol. Users who want the original "type into FSI while the AI watches" experience continue to run HTTP mode (the default).
- **Single binary, single flag.** No new project, no new entry point. `Program.main` parses `--stdio` once, strips it from the arg list, and dispatches to either the existing `createApp` (HTTP) or the new `runStdio` (Generic Host + `WithStdioServerTransport`).
- **Logging.** Default `HostApplicationBuilder` adds a console logger that writes to `stdout`. In `runStdio` we `ClearProviders()` and re-add only the Serilog file sink (already used in HTTP mode for the per-session debug log under `$TMPDIR/fsi-mcp-debugging-<sessionId>.log`). This keeps `stdout` exclusive to JSON-RPC.
- **FSI subprocess output.** `FsiService` writes FSI's piped `stdout`/`stderr` and an input echo to `Console.Out` for the human-in-the-loop case. Three call sites are now gated behind a new optional `isStdio` constructor flag and skipped in stdio mode. The events still land in the in-memory event queue, so `get_recent_fsi_events` returns the full transcript over MCP exactly as in HTTP mode.

## Changes

### `server/FsiService.fs`
- Add optional `?isStdio: bool` constructor parameter (defaults to `false`).
- Gate the three `Console.WriteLine` (+ `Console.Out.Flush`) calls behind `if not isStdio` — FSI stdout pipe (line 72), FSI stderr pipe (lines 85–86), and the API input echo in `SendToFsi` (lines 107–108).
- No behavior change for existing HTTP callers (parameter is optional and defaults to old behavior).

### `server/Program.fs`
- New `runStdio (args: string[]) (sessionId: string)` function that:
  - Builds a `Microsoft.Extensions.Hosting.HostApplicationBuilder`.
  - `Logging.ClearProviders()` then `AddSerilog(Log.Logger)` so nothing writes to `stdout`.
  - Registers `FsiService` with `isStdio = true` and `FsiTools` as before.
  - Calls `.AddMcpServer().WithStdioServerTransport().WithTools<FsiTools>()`.
  - Starts the FSI subprocess and registers `Cleanup` on `IHostApplicationLifetime.ApplicationStopping`.
- `main` now does `let stdioMode = args |> Array.contains "--stdio"`, filters the flag out before passing args downstream, and dispatches to `runStdio` or the existing HTTP path.
- Serilog file sink configuration unchanged (works in both modes — no `stdout` writes).

### `server/fsi-mcp-server.fsproj`
- `<Version>` bumped `0.1.0` → `0.2.0`.

### `README.md`
- Install section shows both `fsi-mcp` (HTTP) and `fsi-mcp --stdio` invocations.
- Claude Code section: primary recommendation is now `claude mcp add -s user fsi-mcp -- fsi-mcp --stdio --nologo` (auto-spawn). HTTP/SSE registration kept as the alternative for users who want the long-lived server + console hybrid.
- Claude Desktop section: stdio JSON config promoted; `mcp-remote` HTTP bridge kept as fallback.

## What is *not* changed

- HTTP/SSE transport, hardcoded `0.0.0.0:5020`, hybrid console-REPL bridge — all still default and unchanged.
- The four MCP tools (`send_fsharp_code`, `load_f_sharp_script`, `get_recent_fsi_events`, `get_fsi_status`) — same names, same schemas, same behavior.
- The `FsiService` HTTP construction path keeps the no-flag overload, so no other call site needs an edit.

## Verification

```bash
dotnet build server/fsi-mcp-server.fsproj   # clean, 0 warnings
```

**HTTP regression** (default mode unchanged):

```bash
dotnet run --project server -- --nologo &
curl http://localhost:5020/health           # → "Ready to work!"
```

**Stdio JSON-RPC handshake** — pipe one frame per line, read response on stdout:

```bash
{
  printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"0"}}}'
  printf '%s\n' '{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}'
  printf '%s\n' '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}'
  printf '%s\n' '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"send_fsharp_code","arguments":{"agentName":"stdio-test","code":"printfn \"hello stdio\";;"}}}'
  sleep 2
  printf '%s\n' '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"get_recent_fsi_events","arguments":{"count":10}}}'
  sleep 1
} | fsi-mcp --stdio --nologo 2>/dev/null
```

| Frame | Response (stdout, JSON-RPC) |
|---|---|
| `initialize` | `{"result":{"protocolVersion":"2024-11-05","capabilities":{...},"serverInfo":{"name":"fsi-mcp-server","version":"0.2.0.0"}},"id":1,"jsonrpc":"2.0"}` |
| `tools/list` | four tools listed (unchanged from HTTP mode) |
| `tools/call send_fsharp_code` | `{"result":{"content":[{"type":"text","text":"Code sent to FSI and logged"}]},"id":3,"jsonrpc":"2.0"}` |
| `tools/call get_recent_fsi_events` | event log includes `INPUT (api:stdio-test): printfn "hello stdio";;`, `OUTPUT (fsi): > hello stdio`, `OUTPUT (fsi): val it: unit = ()` |

`stderr` empty. `stdout` contained only the four JSON-RPC response frames — no banner, no log noise, no FSI echo.

**Real client** — registered with Claude Code:

```bash
claude mcp add -s user fsi-mcp -- fsi-mcp --stdio --nologo
claude mcp list
# fsi-mcp: fsi-mcp --stdio --nologo - ✓ Connected
```

Claude Code spawned the binary, completed the handshake, and exposed the four tools — no manual server start required.

## Notes for maintainers

- This PR depends on the global-tool packaging (PR #prev). Behavior is correct independent of it — `dotnet run --project server -- --stdio` works the same — but the README/`claude mcp add` snippets assume the `fsi-mcp` command is on `PATH`.
- `--stdio` is recognised positionally anywhere in `argv` and removed before the remainder is passed to FSI, so it composes with any FSI args (`fsi-mcp --stdio --nologo --define:DEBUG --load:setup.fsx`).
- The Generic Host path in `runStdio` doesn't reuse the ASP.NET `WebApplication` builder. If you'd prefer a single host with conditional ASP.NET integration to cut the duplication, happy to refactor in a follow-up — keeping them separate here makes the diff easier to review and avoids touching the HTTP path.

## Follow-ups (out of scope)

- CI step that exercises both modes (curl `/health` for HTTP, JSON-RPC pipe for stdio).
- Document the `$TMPDIR/fsi-mcp-debugging-*.log` file in the README and add a `--log-level` / `--no-log` flag.
- Consider auto-detecting `--stdio` when `Console.IsInputRedirected && Console.IsOutputRedirected` — current explicit flag is safer but a one-liner upgrade later.